### PR TITLE
Switch pos_to_pos eltype to Pair{Int, Translation}

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -196,7 +196,8 @@ Translation(pos, 6)
 
 Note that these operations are in __linear time__, as they scan the CIGAR string from the beginning.
 
-To efficiently query multiple translations in the same scan of the CIGAR string, you can pass a sorted (ascending) iterator of integers:
+To efficiently query multiple translations in the same scan of the CIGAR string, you can pass a sorted (ascending) iterator of integers.
+In this case, `pos_to_pos` will return a lazy iterator of `Pair{Int, Translation}`, representing `source_index => destination_index`:
 
 ```jldoctest
 julia> c = CIGAR("4M3D2M2I3M"); # alignment above
@@ -207,11 +208,11 @@ julia> length(it)
 4
 
 julia> collect(it)
-4-element Vector{Translation}:
- Translation(pos, 1)
- Translation(pos, 8)
- Translation(pos, 9)
- Translation(pos, 12)
+4-element Vector{Pair{Int64, Translation}}:
+  1 => Translation(pos, 1)
+  5 => Translation(pos, 8)
+  6 => Translation(pos, 9)
+ 11 => Translation(pos, 12)
 ```
 
 ```@docs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,13 +260,13 @@ end
             it = pos_to_pos(query, aln, c, (i for i in 1:3:25))
             @test it isa T
             @test length(it) == length(1:3:25)
-            @test collect(it) == [query_to_aln(c, i) for i in 1:3:25]
+            @test collect(it) == [i => query_to_aln(c, i) for i in 1:3:25]
 
             v = [-10, 0, 1, 3, 8, 8, 13, 15, 21]
             for coordinate in [query, ref, aln]
                 it = pos_to_pos(coordinate, coordinate, c, v)
                 @test length(it) == length(v)
-                @test [i.pos for i in collect(it)] == map(v) do i
+                @test [last(i).pos for i in it] == map(v) do i
                     L = if coordinate === query
                         query_length(c)
                     elseif coordinate === ref


### PR DESCRIPTION
This is nice, because if `pos_to_pos` is passed an iterator where the values take some time to compute, and we want both the inputs and the output values, we currently need to allocate the inputs in a vector.
