### PR TITLE
Breaking changes for v0.2

### DIFF
--- a/.github/workflows/tagbot.yml
+++ b/.github/workflows/tagbot.yml
@@ -1,0 +1,25 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        description: "[DEPRECATED] No longer has any effect"
+        default: "3"
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-slim
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # For commits that modify workflow files: SSH key enables tagging, but
+          # releases require manual creation. For full automation of such commits,
+          # use a PAT with `workflow` scope instead of GITHUB_TOKEN.
+          # See: https://github.com/JuliaRegistries/TagBot#commits-that-modify-workflow-files
+          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}
+          # changelog_format: github  # 'custom' (default), 'github', or 'conventional'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,6 @@ CIGARStrings.jl provides types for representing CIGAR strings (Concise Idiosyncr
 ### Coordinate Systems
 
 Three coordinate systems: `query`, `ref`, `aln` (alignment with gaps). Position functions like `query_to_ref`, `ref_to_aln` etc. translate between them, returning `Translation` objects with `.kind` (outside/pos/gap) and `.pos`.
+
+### When committing
+Do not add yourself (you, the agent) as a co-author.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,6 @@ CIGARStrings.jl provides types for representing CIGAR strings (Concise Idiosyncr
 - Both CIGAR types store precomputed `aln_len`, `ref_len`, `query_len` for O(1) length queries
 - Parsing uses `try_parse` returning `Union{T, CIGARError}` pattern (no exceptions on invalid input)
 - Memory is backed by `ImmutableMemoryView{UInt8}` from MemoryViews.jl
-- Internal `Unsafe` sentinel type for constructors that skip validation
 - Position translation via `pos_to_pos(from, to, cigar, positions)` returns lazy `PositionMapper` iterator
 
 ### Coordinate Systems

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ julia --project --startup=no
 julia --project=docs --startup=no docs/make.jl
 ```
 
+When running in test mode, Julia has boundscheck always enabled. When running normally,
+out-of-bounds access in functions marked `@inbounds` is undefined behaviour.
+Set `--check-bounds=yes` to force boundschecking when running experiments.
+
 ## Architecture
 
 CIGARStrings.jl provides types for representing CIGAR strings (Concise Idiosyncratic Gapped Alignment Reports) used in the SAM/BAM bioinformatics formats.

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ version = "0.2.0"
 authors = ["Jakob Nybo Nissen <jakobnybonissen@gmail.com>"]
 
 [deps]
+LightBoundsErrors = "e21c612c-4641-4669-b9c3-3f4360ced9da"
 MemoryViews = "a791c907-b98b-4e44-8f4d-e4c2362c6b2f"
 
 [compat]
 FormatSpecimens = "1.3.0"
-MemoryViews = "0.2.1, 0.3"
+LightBoundsErrors = "1.1.0"
+MemoryViews = "0.4"
 Test = "1.11"
 julia = "1.11"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CIGARStrings"
 uuid = "e5b51f81-6ffd-4e20-bbec-f118e37ea906"
-version = "0.1.8"
+version = "0.2.0"
 authors = ["Jakob Nybo Nissen <jakobnybonissen@gmail.com>"]
 
 [deps]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,8 +8,8 @@ end
 ```
 
 # CIGARStrings.jl
-CIGARStrings.jl provide functionality for parsing and working with Concise Idiosyncratic Gapped Alignment Report - or CIGAR - strings.
-CIGARs were popularized by the [SAM format](https://en.wikipedia.org/wiki/SAM_(file_format)), and are a compact run length encoding notation to represent pairwise alignments.
+CIGARStrings.jl provides functionality for parsing and working with Concise Idiosyncratic Gapped Alignment Report (CIGAR) strings.
+CIGARs were popularized by the [SAM format](https://en.wikipedia.org/wiki/SAM_(file_format)), and are a compact run-length encoding notation used to represent pairwise alignments.
 They can be found in the SAM, BAM, PAF, and GFA formats.
 
 For example, the following pairwise alignment of a query to a reference:
@@ -19,17 +19,17 @@ For example, the following pairwise alignment of a query to a reference:
        ||||    ||  | |
     R: TAGAACCATA--TGC
 ```
-Can be represented by the CIGAR `5M3D2M2I3M`, representing:
+can be represented by the CIGAR `5M3D2M2I3M`, representing:
 1. 5 matches/mismatches
 2. Then, 3 deletions
 3. Then, 2 matches/mismatches
 4. Then, 2 insertions
 5. Finally, 3 matches/mismatches.
 
-A CIGAR strings is always written in terms of the _query_, and not the reference. 
+A CIGAR string is always written in terms of the _query_, not the reference.
 
 ## Individual alignment operations
-One run of identical alignment operations, e.g. "5 matches/mismatches" are represented
+One run of identical alignment operations, e.g. "5 matches/mismatches," is represented
 by a single `CIGARElement`.
 Conceptually, a `CIGARElement` is an alignment operation (represented by a `CIGAROp`) and a length:
 
@@ -41,16 +41,16 @@ CIGAROp
 ## CIGARs
 A CIGAR string is represented by an `AbstractCIGAR`, which currently has two subtypes: `CIGAR` and `BAMCIGAR`.
 These types differ in their memory layout: The former stores the CIGAR as its ASCII representation (as used in the SAM format), and the latter stores it in a binary format (as used in the BAM format).
-Both typs store its underlying data as an `ImmutableMemoryView{UInt8}`.
+Both types store their underlying data as an `ImmutableMemoryView{UInt8}`.
 
 ```@docs
 AbstractCIGAR
 ```
 
-The API for these two types are almost interchangeable, so examples below will use `CIGAR`, since its plaintext representation makes examples easier.
+The API for these two types is almost interchangeable, so examples below use `CIGAR`, since its plaintext representation makes examples easier to read.
 See [BAMCIGAR section](@ref bamcigar) for a list of all differences between the two types.
 
-CIGAR strings are validated upon construction
+CIGAR strings are validated upon construction.
 
 ```jldoctest
 julia> CIGAR("2M1D3M")
@@ -64,7 +64,7 @@ ERROR: Error around byte 4: Invalid operation. Possible values are "MIDNSHP=X".
 Since CIGAR strings occur in various bioinformatics file formats, it is expected
 that users of CIGARStrings.jl will construct `CIGAR`s from a view into a buffer storing a chunk of the file.
 
-This is zero-copy, and will not to allocate on Julia 1.14 and forward.
+This is zero-copy, and does not allocate on Julia 1.14 and later.
 For example:
 
 ```jldoctest
@@ -80,7 +80,7 @@ CIGAR("15M9D18M")
 CIGAR
 ```
 
-`CIGAR`s are iterable, and returns its `CIGARElement`s, in order:
+`CIGAR`s are iterable, and return their `CIGARElement`s in order:
 
 ```jldoctest
 julia> collect(CIGAR("2M1D3M"))
@@ -129,8 +129,6 @@ alignment length is 15.
     R: TAGAACCATA--TGC
 ```
 
-We always have `aln_length(c) ≥ max(query_length(c), ref_length(c))`
-
 ```jldoctest
 julia> c = CIGAR("5M3D2M2I3M");
 
@@ -144,19 +142,19 @@ julia> aln_length(c)
 15
 ```
 
-Since the CIGAR operation `M` (`OP_M`) is ambiguous to whether is represents matches,
+Since the CIGAR operation `M` (`OP_M`) is ambiguous about whether it represents matches,
 mismatches, or a combination of these, the function [`count_matches`](@ref) can be used to
 count the number of matches in a CIGAR given the number of mismatches.
 
-The number of mismatches are typically output by mappers, making this information
-handily accessible:
+Mismatch counts are typically output by mappers, making this information
+readily accessible.
 
-The alignment identity (number of matches, not mismatches divided by alignment length)
+Alignment identity (number of matches, excluding mismatches, divided by alignment length)
 can be obtained with [`aln_identity`](@ref).
-Like [`count_matches`](@ref), this takes the number of mismatches as an argument:
+Like [`count_matches`](@ref), this takes the number of mismatches as an argument.
 
 ## Comparing CIGARs
-When comparing `CIGAR`s using `==`, it will check if the `CIGAR`s are literally identical, in the
+When comparing `CIGAR`s using `==`, Julia checks whether the `CIGAR`s are literally identical, in the
 sense that they are composed of the same bytes:
 
 ```jldoctest compare
@@ -176,7 +174,7 @@ However, in the above example, since the CIGAR operation `M` signifies a match o
 CIGARs are indeed compatible, since `10M` is also a valid CIGAR annotation for the same alignment
 as `4=1X5=`.
 
-This notion of compatibility tested with `is_compatible`:
+This notion of compatibility can be tested with `is_compatible`:
 
 ```@docs
 is_compatible
@@ -204,10 +202,10 @@ are also written in this alignment.
 We can see that query position 6 aligns to reference position 9, which is also
 alignment position 9.
 
-These position translation can be obtained using the function [`pos_to_pos`](@ref),
+These position translations can be obtained using the function [`pos_to_pos`](@ref),
 specifying the source and destination coordinate systems [`query`](@ref), [`ref`](@ref)
 or [`aln`](@ref).
-When passed an integer, this function returns `Translation` object that contains two properties: `.pos` and `.kind`.
+When passed an integer, this function returns a `Translation` object with two properties: `.pos` and `.kind`.
 
 When a position translation has a straightforward answer, the `.kind` property is
 `CIGARStrings.pos`, and the `.pos` field is the corresponding position:
@@ -222,10 +220,10 @@ julia> pos_to_pos(aln, query, c, 9)
 Translation(pos, 6)
 ```
 
-Note that these operations are in __linear time__, as they scan the CIGAR string from the beginning.
+Note that these operations run in __linear time__, as they scan the CIGAR string from the beginning.
 
 To efficiently query multiple translations in the same scan of the CIGAR string, you can pass a sorted (ascending) iterator of integers.
-In this case, `pos_to_pos` will return a lazy iterator of `Pair{Int, Translation}`, representing `source_index => destination_index`:
+In this case, `pos_to_pos` returns a lazy iterator of `Pair{Int, Translation}`, representing `source_position => mapped_translation`:
 
 ```jldoctest
 julia> c = CIGAR("4M3D2M2I3M"); # alignment above
@@ -252,21 +250,21 @@ CIGARStrings.TranslationKind
 ## Normalization
 The CIGAR format is redundant, in that the same alignment can be written in multiple different ways. In particular:
 
-* The `P` and `H` operations means nothing w.r.t the query and reference.
-  `P` is only used to pad w.r.t a third sequence, and `H` signifies that part of
+* The `P` and `H` operations mean nothing with respect to the query and reference.
+  `P` is only used to pad with respect to a third sequence, and `H` signifies that part of
   the true query is missing from the input query sequence.
 * The `=` and `X` operations are usually redundant with `M`, since the information of matches/mismatches is not given by the alignment itself, but can be determined from the input sequences given the alignment.
-* Consecutive runs of the same operation is allowed, such as `1M1M`, but is better written `2M`
+* Consecutive runs of the same operation are allowed, such as `1M1M`, but are better written as `2M`.
 
-This package provides the functions [`normalize`](@ref), [`normalize!`](@ref) and [`unsafe_normalize`](@ref) which creates new cigars written in the canonical form.
-In the canonical form, each of the points above are addressed: `H` is converted to `S`, `P` is removed, `=` and `X` is converted to `M`, and consecutive identical operations are merged.
+This package provides the functions [`normalize`](@ref), [`normalize!`](@ref), and [`unsafe_normalize`](@ref), which create new CIGARs written in canonical form.
+In canonical form, each of the points above is addressed: `H` and `P` is removed, `=` and `X` are converted to `M`, and consecutive identical operations are merged.
 
-Note that the normalized form of a cigar corresponds to the _same_ pairwise alignment.
+Note that the normalized form of a CIGAR corresponds to the _same_ pairwise alignment.
 Therefore, it is guaranteed that if `is_compatible(a, b)`, then `normalize(a) == normalize(b)` (though not the other way around).
-It is also guaranteed that the result of position translation is identical for a cigar and its normalized version.
+It is also guaranteed that the result of position translation is identical for a CIGAR and its normalized version.
 
 ## Errors and error recovery
-CIGARStrings.jl allows you to parse a poential CIGAR string without throwing an exception if the data is invalid, using the function [`CIGARStrings.try_parse`](@ref).
+CIGARStrings.jl allows you to parse a potential CIGAR string without throwing an exception if the data is invalid, using the function [`CIGARStrings.try_parse`](@ref).
 
 ```@docs
 CIGARStrings.CIGARError
@@ -282,14 +280,14 @@ However, in order to make zero-copy CIGARs possible, the `BAMCIGAR` type is back
 CIGARStrings.BAMCIGAR
 ```
 
-A `BAMCIGAR` can be constructed from its binary representation, using any type which implements `MemoryViews.MemoryView`:
+A `BAMCIGAR` can be constructed from its binary representation using any type that implements `MemoryViews.MemoryView`:
 
 ```jldoctest
 julia> BAMCIGAR("\x54\4\0\0\x70\4\0\0")
 BAMCIGAR(CIGAR("69S71M"))
 ```
 
-This is not zero-cost: Like `CIGAR` the type contains some metadata and is validated upon construction.
+This is not zero-cost: like `CIGAR`, the type contains some metadata and is validated upon construction.
 
 Like `CIGAR`, the `try_parse` function can be used:
 
@@ -298,7 +296,7 @@ julia> CIGARStrings.try_parse(BAMCIGAR, "\x5f\4\0\0\x70\4\0\0")
 CIGARStrings.CIGARError(1, CIGARStrings.Errors.InvalidOperation)
 ```
 
-`CIGAR` and `BAMCIGAR` can be converted ifallably to each other:
+`CIGAR` and `BAMCIGAR` can be converted infallably to each other:
 
 ```jldoctest
 julia> c = CIGAR("6H19S18M1I22=8I2S");

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -252,8 +252,9 @@ CIGARStrings.TranslationKind
 ## Normalization
 The CIGAR format is redundant, in that the same alignment can be written in multiple different ways. In particular:
 
-* The `S` and `H` operation is semantically identical, so `5H10M` and `5S10M` means the same thing
-* The `P` operation means nothing w.r.t the query and reference and is only used to pad w.r.t a third sequence
+* The `P` and `H` operations means nothing w.r.t the query and reference.
+  `P` is only used to pad w.r.t a third sequence, and `H` signifies that part of
+  the true query is missing from the input query sequence.
 * The `=` and `X` operations are usually redundant with `M`, since the information of matches/mismatches is not given by the alignment itself, but can be determined from the input sequences given the alignment.
 * Consecutive runs of the same operation is allowed, such as `1M1M`, but is better written `2M`
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -279,7 +279,6 @@ However, in order to make zero-copy CIGARs possible, the `BAMCIGAR` type is back
 
 ```@docs
 CIGARStrings.BAMCIGAR
-CIGARStrings.BAMCIGAR(::MutableMemoryView{UInt8}, ::CIGAR)
 ```
 
 A `BAMCIGAR` can be constructed from its binary representation, using any type which implements `MemoryViews.MemoryView`:
@@ -313,8 +312,3 @@ true
 ```
 
 Note that printing a `BAMCIGAR` allocates, because it needs to allocate a new piece of memory to store its ASCII representation.
-For high performance applications, the function `cigar_view!` may be used:
-
-```@docs
-CIGARStrings.cigar_view!
-```

--- a/src/CIGARStrings.jl
+++ b/src/CIGARStrings.jl
@@ -564,7 +564,7 @@ end
     query_length(::AbstractCIGAR)::Int
 
 Get the number of biosymbols in the query of the `CIGAR`. This is the same
-as the lengths of all `CIGARElement`s of type `M`, `I`, `S`, `H`, `=` and `X`.
+as the lengths of all `CIGARElement`s of type `M`, `I`, `S`, `=` and `X`.
 
 See also: [`ref_length`](@ref), [`aln_length`](@ref)
 

--- a/src/CIGARStrings.jl
+++ b/src/CIGARStrings.jl
@@ -15,6 +15,8 @@ public CIGARError, CIGARErrorType, Errors, try_parse, outside, pos, gap,
 
 using MemoryViews: MemoryViews, ImmutableMemoryView, MemoryView, MutableMemoryView
 
+using LightBoundsErrors: throw_lightboundserror, checkbounds_lightboundserror
+
 struct Unsafe end
 const unsafe = Unsafe()
 
@@ -280,7 +282,7 @@ include("bamcigar.jl")
 Encode `cigar` as type `T` into the beginning of `mem`,
 and return the result as a new `T` backed by `mem`.
 
-Throw a `BoundsError` if `mem` is too short to contain the whole encoding.
+Throw a `LightBoundsError` if `mem` is too short to contain the whole encoding.
 
 !!! warning
     Since the first bytes of `mem` are used to back the newly created cigar,
@@ -304,7 +306,7 @@ true
 """
 function encode!(mem::MutableMemoryView{UInt8}, ::Type{BAMCIGAR}, cigar::BAMCIGAR)
     src_mem = MemoryView(cigar)
-    @boundscheck checkbounds(mem, eachindex(src_mem))
+    @boundscheck checkbounds_lightboundserror(mem, eachindex(src_mem))
     @inbounds copyto!(mem, src_mem)
     dst = @inbounds ImmutableMemoryView(mem)[eachindex(src_mem)]
     return BAMCIGAR(unsafe, dst, cigar.aln_len, cigar.ref_len, cigar.query_len)
@@ -312,7 +314,7 @@ end
 
 function encode!(mem::MutableMemoryView{UInt8}, ::Type{CIGAR}, cigar::CIGAR)
     src_mem = MemoryView(cigar)
-    @boundscheck checkbounds(mem, eachindex(src_mem))
+    @boundscheck checkbounds_lightboundserror(mem, eachindex(src_mem))
     @inbounds copyto!(mem, src_mem)
     dst = @inbounds ImmutableMemoryView(mem)[eachindex(src_mem)]
     return CIGAR(unsafe, dst, cigar.n_ops, cigar.aln_len, cigar.ref_len, cigar.query_len)
@@ -320,7 +322,7 @@ end
 
 function encode!(mem::MutableMemoryView{UInt8}, ::Type{BAMCIGAR}, cigar::CIGAR)
     nbytes = 4 * length(cigar)
-    @boundscheck checkbounds(mem, 1:nbytes)
+    @boundscheck checkbounds_lightboundserror(mem, 1:nbytes)
     mem = @inbounds mem[1:nbytes]
     GC.@preserve mem begin
         ptr = Ptr{UInt32}(pointer(mem))
@@ -688,10 +690,10 @@ function normalize end
 Same as [`normalize`](@ref), but uses allocation of `mem` instead of allocating
 a new array.
 
-Throws a `BoundsError` if `mem` cannot hold the normalized cigar.
+Throws a `LightBoundsError` if `mem` cannot hold the normalized cigar.
 A cigar after normalization is guaranteed to use at most as much memory
 as cigar before normalization, so if `length(mem) ≥ length(MemoryView(cigar))`,
-a `BoundsError` cannot happen.
+a bounds error cannot happen.
 
 !!! warning
     If `mem` aliases `MemoryView(cigar)`,

--- a/src/CIGARStrings.jl
+++ b/src/CIGARStrings.jl
@@ -58,7 +58,7 @@ Exception kind thrown by the package CIGARStrings.
 and `.index`, returning an `Int`, pointing to the approximate byte index where the
 exception was encountered.
 
-The `kind` and `pos` are stable API, in the sense that e.g. an integer overflow
+The `kind` and `index` are stable API, in the sense that e.g. an integer overflow
 at position 55 will always be represented by a
 `CIGARError(55, CIGARStrings.Errors.IntegerOverflow)`.
 However, the same invalid CIGAR string may produce multiple different errors, and which
@@ -905,7 +905,7 @@ n_symbols(::Ref, x::AbstractCIGAR) = ref_length(x)
 n_symbols(::Aln, x::AbstractCIGAR) = aln_length(x)
 
 """
-    pos_to_pos(from::Coordinate, to::Coordinate, cigar::AbstractCIGAR, pos::Integer)::Integer
+    pos_to_pos(from::Coordinate, to::Coordinate, cigar::AbstractCIGAR, pos::Integer)::Translation
 
 Similar to the generic `pos_to_pos`, but returns the resulting integer immediately instead of returning
 a lazy iterator.

--- a/src/CIGARStrings.jl
+++ b/src/CIGARStrings.jl
@@ -5,7 +5,7 @@ export CIGAR,
     CIGARElement, ref_length, aln_length, query_length, aln_identity,
     query_to_ref, query_to_aln, ref_to_query, ref_to_aln,
     aln_to_query, aln_to_ref, Translation, count_matches,
-    BAMCIGAR, AbstractCIGAR, cigar_view!, ref, query, aln, pos_to_pos,
+    BAMCIGAR, AbstractCIGAR, ref, query, aln, pos_to_pos,
     unsafe_switch_memory, is_compatible,
     normalize, unsafe_normalize, normalize!,
     encode!, encode_append!

--- a/src/CIGARStrings.jl
+++ b/src/CIGARStrings.jl
@@ -124,8 +124,8 @@ then the positions are `(A, B+9, C+9)` after.
 | 1 | `Q   A`  |`OP_I`   | I    | Insertion relative to the reference                  |
 | 2 | `  R A`  |`OP_D`   | D    | Deletion relative to the reference                   |
 | 3 | `  R  `  |`OP_N`   | N    | Reference skipped from the alignment (usually an intron)|
-| 4 | `Q    `  |`OP_S`   | S    | Soft clip (semantically identical to hard clip)      |
-| 5 | `Q    `  |`OP_H`   | H    | Hard clip (semantically identical to soft clip)      |
+| 4 | `Q    `  |`OP_S`   | S    | Soft clip (consumes query)                           |
+| 5 | `     `  |`OP_H`   | H    | Hard clip (does not consume query)                   |
 | 6 | `     `  |`OP_P`   | P    | Padding, position not present in query or reference  |
 | 7 | `Q R A`  |`OP_Eq`  | =    | Alignment match, not mismatch                        |
 | 8 | `Q R A`  |`OP_X`   | X    | Alignment mismatch                                   |
@@ -141,11 +141,12 @@ See also: [`CIGARElement`](@ref)
   is deleted, but not due to an actual deletion (which would be a `D` operation).
   It can also be used for other uses where the reference bases are missing
   for another reason than a deletion, if such a use case is found.
-* `S` and `H` are semantically identical. They both signify the end(s) of the
-  query sequence which are not part of the alignment. They differ only in whether
-  the clipped bases are written in the SEQ field of a SAM record.
-  Typically, hard-clipped bases are present as soft clipped bases in another
-  record, such that writing them in both records would be wasteful.
+* `S` and `H` both represent that ends of query does not align.
+  They differ only in whether the clipped bases, i.e. the ends of the query sequence
+  not part of the alignment, are present in the query sequence.
+  For soft clip, the sequence is present in the query, but not for hard clip. 
+  Soft clip is preferred, and hard clip is only used in rare cases where removing
+  part of the query sequence can lead to memory savings.
 * `P` is only used for a multiple sequence alignment. If a third sequence contains an
   insertion relative to both the query and the reference, the query has a
   `P` at this position, indicating it's present in neither the query nor reference.
@@ -431,7 +432,7 @@ end
 
 const CONSUMES = let
     x = UInt32(0)
-    for query in [OP_M, OP_I, OP_S, OP_H, OP_Eq, OP_X] # not PDN
+    for query in [OP_M, OP_I, OP_S, OP_Eq, OP_X] # not PDNH
         shift = reinterpret(UInt8, query) * 3
         x |= UInt32(1) << shift
     end
@@ -451,10 +452,6 @@ end
 
 Return whether the given CIGAROp consumes (i.e. uses up) bases of the query,
 reference, and alignment, respectively.
-Note that this DOES NOT exactly match the definition as stated in the SAM specs,
-because in those, "consumes query" means whether it consumes bases of the query
-as printed in the SEQ field, and the SEQ field does not include bases marked as
-`OP_H`, despite these actually being part of the query.
 """
 function consumes(x::CIGAROp)::@NamedTuple{query::Bool, ref::Bool, aln::Bool}
     n = CONSUMES >>> ((3 * reinterpret(UInt8, x)) & 31)
@@ -654,9 +651,8 @@ Create a new `AbstractCIGAR`, where the same alignment as `cigar`
 is written in its canonical form.
 
 The normalization process makes the following changes:
-* `OP_H` is converted to `OP_S`
 * `OP_Eq` and `OP_X` are converted to `OP_M`
-* `OP_P` operations are removed
+* `OP_P` and `OP_H` operations are removed
 * Consecutive elements with the same operations are merged
 
 The resulting cigar therefore only contain the operations:
@@ -677,8 +673,8 @@ See also: [`normalize!`](@ref), [`unsafe_normalize`](@ref), [`is_compatible`](@r
 
 # Examples
 ```jldoctest
-julia> normalize(CIGAR("2H3=1X2=4P3=1=1I2X4H"))
-CIGAR("2S10M1I2M4S")
+julia> normalize(CIGAR("2H2S3=1X2=4P3=1=1I2X4H"))
+CIGAR("2S10M1I2M")
 
 julia> normalize(CIGAR("5M1D8M1I7M"))
 CIGAR("5M1D8M1I7M")
@@ -1067,8 +1063,7 @@ ways to annotate the same alignment. In particular, the following rules are used
 when determining if distinct CIGAR operations are equivalent:
 * Two consecutive of the same operations may be collapsed, ex: `1M1M` and `2M`
 * An `OP_M` can encompass both `OP_X` and `OP_Eq`, ex: `3M` and `1X1M1=`
-* `OP_S` and `OP_H` are semantically identical, ex: `2S` and `2H` 
-* `OP_P` has no semantic meaning and is skipped: `1D1P2D1M3P` and `3D1M`
+* `OP_P` and `OP_H` have no semantic meaning and is skipped: `1D1P2D1M3P` and `3D1M`
 
 See also: [`normalize`](@ref)
 
@@ -1136,7 +1131,7 @@ function next_meaningful(
     )::Union{Nothing, Tuple{CIGARElement, Any}}
     while it_return !== nothing
         (elem, state) = it_return
-        elem.op != OP_P && return it_return
+        elem.op ∉ (OP_P, OP_H) && return it_return
         it_return = iterate(cigar, state)
     end
     return nothing
@@ -1144,13 +1139,13 @@ end
 
 # Below is a bitmask, where each chunk of 7 bits correspond to a CIGAR op.
 # The bitfield is a map of which operations it's compatible with.
-# E.g. OP_S and OP_H are compatible with each other, so they have bit 3
-# in the 7-bit bitfield set.
+# OP_P and OP_H share the same compatibility bits, because both are skipped
+# when comparing semantic alignment compatibility.
 
-# Order of bits: X   =   P  H/S   N   D   I
+# Order of bits: X   =  P/H  S   N   D   I
 #          OP_M: 1___1___0___0____0___0___0
 #                       X       =      P        H       S       N      D        I       M
-const COMPAT_LUT = 0b1000000_0100000_0010000_0001000_0001000_0000100_0000010_0000001_1100000
+const COMPAT_LUT = 0b1000000_0100000_0010000_0010000_0001000_0000100_0000010_0000001_1100000
 
 rsh(a::UInt64, b) = a >> (b & 0x3f)
 

--- a/src/CIGARStrings.jl
+++ b/src/CIGARStrings.jl
@@ -17,9 +17,6 @@ using MemoryViews: MemoryViews, ImmutableMemoryView, MemoryView, MutableMemoryVi
 
 using LightBoundsErrors: throw_lightboundserror, checkbounds_lightboundserror
 
-struct Unsafe end
-const unsafe = Unsafe()
-
 @noinline unreachable() = error("Unreachable reached")
 
 baremodule Errors
@@ -222,8 +219,8 @@ struct CIGARElement
     # 28 upper bits: Value, lower 4 bits: CIGAROp
     x::UInt32
 
-    CIGARElement(::Unsafe, x::UInt32) = new(x)
-    function CIGARElement(::Unsafe, op::CIGAROp, len::UInt32)
+    global unsafe_cigarelement(x::UInt32) = new(x)
+    global function unsafe_cigarelement(op::CIGAROp, len::UInt32)
         return new((reinterpret(UInt8, op) % UInt32) | (len << 4))
     end
 end
@@ -232,7 +229,7 @@ function CIGARElement(op::CIGAROp, len::Integer)
     ulen = UInt32(len)::UInt32
     ulen > 0x0fffffff && error("CIGARStrings only support cigar operations of length 268435455")
     iszero(ulen) && error("CIGAR cannot have zero-length element")
-    return CIGARElement(unsafe, op, ulen)
+    return unsafe_cigarelement(op, ulen)
 end
 
 function Base.show(io::IO, x::CIGARElement)
@@ -254,7 +251,7 @@ function unsafe_subtract_length(x::CIGARElement, len::UInt32)
     xx = getfield(x, :x)
     u = xx >> 4
     u -= len
-    return CIGARElement(unsafe, u << 4 | (xx & 0x0f))
+    return unsafe_cigarelement(u << 4 | (xx & 0x0f))
 end
 
 """
@@ -309,7 +306,7 @@ function encode!(mem::MutableMemoryView{UInt8}, ::Type{BAMCIGAR}, cigar::BAMCIGA
     @boundscheck checkbounds_lightboundserror(mem, eachindex(src_mem))
     @inbounds copyto!(mem, src_mem)
     dst = @inbounds ImmutableMemoryView(mem)[eachindex(src_mem)]
-    return BAMCIGAR(unsafe, dst, cigar.aln_len, cigar.ref_len, cigar.query_len)
+    return unsafe_bamcigar(dst, cigar.aln_len, cigar.ref_len, cigar.query_len)
 end
 
 function encode!(mem::MutableMemoryView{UInt8}, ::Type{CIGAR}, cigar::CIGAR)
@@ -317,7 +314,7 @@ function encode!(mem::MutableMemoryView{UInt8}, ::Type{CIGAR}, cigar::CIGAR)
     @boundscheck checkbounds_lightboundserror(mem, eachindex(src_mem))
     @inbounds copyto!(mem, src_mem)
     dst = @inbounds ImmutableMemoryView(mem)[eachindex(src_mem)]
-    return CIGAR(unsafe, dst, cigar.n_ops, cigar.aln_len, cigar.ref_len, cigar.query_len)
+    return unsafe_cigar(dst, cigar.n_ops, cigar.aln_len, cigar.ref_len, cigar.query_len)
 end
 
 function encode!(mem::MutableMemoryView{UInt8}, ::Type{BAMCIGAR}, cigar::CIGAR)
@@ -332,7 +329,7 @@ function encode!(mem::MutableMemoryView{UInt8}, ::Type{BAMCIGAR}, cigar::CIGAR)
             ptr += 4
         end
     end
-    return BAMCIGAR(unsafe, ImmutableMemoryView(mem), cigar.aln_len, cigar.ref_len, cigar.query_len)
+    return unsafe_bamcigar(ImmutableMemoryView(mem), cigar.aln_len, cigar.ref_len, cigar.query_len)
 end
 
 function encode!(mem::MutableMemoryView{UInt8}, ::Type{CIGAR}, cigar::BAMCIGAR)
@@ -357,7 +354,7 @@ function encode!(mem::MutableMemoryView{UInt8}, ::Type{CIGAR}, cigar::BAMCIGAR)
         mem[len += 1] = byte
     end
     result_mem = @inbounds ImmutableMemoryView(mem)[1:len]
-    return CIGAR(unsafe, result_mem, length(cigar) % UInt32, cigar.aln_len, cigar.ref_len, cigar.query_len)
+    return unsafe_cigar(result_mem, length(cigar) % UInt32, cigar.aln_len, cigar.ref_len, cigar.query_len)
 end
 
 """
@@ -429,7 +426,7 @@ function encode_append!(v::Vector{UInt8}, ::Type{CIGAR}, cigar::BAMCIGAR)
         push!(v, ((CIGAR_BYTE_LUT >> shift) % UInt8) & 0x7f)
     end
     result_mem = @inbounds ImmutableMemoryView(v)[(old_len + 1):end]
-    return CIGAR(unsafe, result_mem, length(cigar) % UInt32, cigar.aln_len, cigar.ref_len, cigar.query_len)
+    return unsafe_cigar(result_mem, length(cigar) % UInt32, cigar.aln_len, cigar.ref_len, cigar.query_len)
 end
 
 const CONSUMES = let
@@ -517,17 +514,17 @@ struct Translation
     # 4 upper bits for Kind (in case more is needed)
     x::UInt64
 
-    Translation(::Unsafe, x::UInt64) = new(x)
+    global unsafe_translation(x::UInt64) = new(x)
 end
 
 function Translation(kind::TranslationKind, pos::Int)
     unsigned(pos) > 0x0fffffffffffffff && error("Cannot translate position > 1152921504606846975")
-    return Translation(unsafe, kind, pos)
+    return unsafe_translation(kind, pos)
 end
 
-function Translation(::Unsafe, kind::TranslationKind, pos::Int)
+function unsafe_translation(kind::TranslationKind, pos::Int)
     n = (pos % UInt64) | ((reinterpret(UInt8, kind) % UInt64) << 60)
-    return Translation(unsafe, n)
+    return unsafe_translation(n)
 end
 
 const outside_translation = Translation(outside, 0)
@@ -716,7 +713,7 @@ julia> MemoryView(c2) === ImmutableMemoryView(mem)
 true
 
 julia> c2 = normalize!(c, MemoryView([0x00]))
-ERROR: BoundsError:
+ERROR: LightBoundsErrors.LightBoundsError: out-of-bounds indexing: `collection[2]`, where:
 [...]
 ```
 """
@@ -790,7 +787,7 @@ struct PositionMapper{I, C, S, D}
     get_dst::D
 end
 
-const SENTINEL_ELEMENT = CIGARElement(unsafe, typemax(UInt32))
+const SENTINEL_ELEMENT = unsafe_cigarelement(typemax(UInt32))
 
 Base.IteratorSize(::Type{<:PositionMapper{I}}) where {I} = Base.IteratorSize(I)
 Base.length(x::PositionMapper) = length(x.integers)
@@ -853,7 +850,7 @@ end
     # When mapping to own coordinate system we just care if it's inbounds.
     if mapper.get_dst === mapper.get_src
         target > n_symbols(mapper.get_dst, mapper.cigar) && return (target => outside_translation, new_state)
-        return (target => Translation(unsafe, pos, target), new_state)
+        return (target => unsafe_translation(pos, target), new_state)
     end
     while true
         element === SENTINEL_ELEMENT && return (target => outside_translation, new_state)
@@ -863,9 +860,9 @@ end
             in(element.op, (OP_S, OP_H)) && return (target => outside_translation, new_state)
             # Non-gap elements increment the source position.
             if mapper.get_dst(next_anchor) > mapper.get_dst(anchor)
-                return (target => Translation(unsafe, pos, mapper.get_dst(anchor) + (target - mapper.get_src(anchor))), new_state)
+                return (target => unsafe_translation(pos, mapper.get_dst(anchor) + (target - mapper.get_src(anchor))), new_state)
             else
-                return (target => Translation(unsafe, gap, Int(mapper.get_dst(anchor))), new_state)
+                return (target => unsafe_translation(gap, Int(mapper.get_dst(anchor))), new_state)
             end
         else
             (element, cigar_state) = let

--- a/src/bamcigar.jl
+++ b/src/bamcigar.jl
@@ -21,7 +21,7 @@ or [`BAMCIGAR(::MutableMemoryView{UInt8}, ::CIGAR)`](@ref)
 ```jldoctest
 julia> c = CIGAR("9S123M1=3I15M2H");
 
-julia> b = BAMCIGAR(c, UInt8[]); # use existing storage
+julia> b = BAMCIGAR(c);
 
 julia> c == b
 true
@@ -130,7 +130,9 @@ function try_parse(::Type{BAMCIGAR}, x)::Union{CIGARError, BAMCIGAR}
         last_was_H = op === OP_H
         is_first = false
     end
-    max(aln_len, n_ops) > typemax(UInt32) && return CIGARError(lastindex(mem) - 3, Errors.IntegerOverflow)
+    if max(aln_len, ref_len, query_len) > typemax(UInt32)
+        return CIGARError(lastindex(mem), Errors.IntegerOverflow)
+    end
     return BAMCIGAR(unsafe, mem, aln_len % UInt32, ref_len % UInt32, query_len % UInt32)
 end
 

--- a/src/bamcigar.jl
+++ b/src/bamcigar.jl
@@ -206,10 +206,8 @@ function normalize!(cigar::BAMCIGAR, mem::MutableMemoryView{UInt8})::BAMCIGAR
     last_element = CIGARElement(unsafe, UInt32(0x00_00_00_10))
     GC.@preserve mem begin
         for element in cigar
-            element.op === OP_P && continue
-            op = if element.op === OP_H
-                OP_S
-            elseif element.op ∈ (OP_X, OP_Eq)
+            element.op ∈ (OP_P, OP_H) && continue
+            op = if element.op ∈ (OP_X, OP_Eq)
                 OP_M
             else
                 element.op

--- a/src/bamcigar.jl
+++ b/src/bamcigar.jl
@@ -36,8 +36,7 @@ struct BAMCIGAR <: AbstractCIGAR
     ref_len::UInt32
     query_len::UInt32
 
-    function BAMCIGAR(
-            ::Unsafe,
+    global function unsafe_bamcigar(
             mem::ImmutableMemoryView{UInt8},
             aln_len::UInt32,
             ref_len::UInt32,
@@ -62,7 +61,7 @@ function Base.iterate(
     )::Union{Tuple{CIGARElement, Int}, Nothing}
     (state - 1) % UInt >= (length(x.mem) % UInt) && return nothing
     u = load_le_u32(x.mem, state)
-    return (CIGARElement(unsafe, u), state + 4)
+    return (unsafe_cigarelement(u), state + 4)
 end
 
 @inline function load_le_u32(mem::ImmutableMemoryView{UInt8}, i::Int)
@@ -133,7 +132,7 @@ function try_parse(::Type{BAMCIGAR}, x)::Union{CIGARError, BAMCIGAR}
     if max(aln_len, ref_len, query_len) > typemax(UInt32)
         return CIGARError(lastindex(mem), Errors.IntegerOverflow)
     end
-    return BAMCIGAR(unsafe, mem, aln_len % UInt32, ref_len % UInt32, query_len % UInt32)
+    return unsafe_bamcigar(mem, aln_len % UInt32, ref_len % UInt32, query_len % UInt32)
 end
 
 function Base.:(==)(x::BAMCIGAR, y::BAMCIGAR)
@@ -172,7 +171,7 @@ ref_length(x::BAMCIGAR) = x.ref_len % Int
 aln_length(x::BAMCIGAR) = x.aln_len % Int
 
 function unsafe_switch_memory(x::BAMCIGAR, mem::ImmutableMemoryView{UInt8})
-    return BAMCIGAR(unsafe, mem, x.aln_len, x.ref_len, x.query_len)
+    return unsafe_bamcigar(mem, x.aln_len, x.ref_len, x.query_len)
 end
 
 function count_matches(x::BAMCIGAR, mismatches::Integer)::Int
@@ -203,7 +202,7 @@ end
 function normalize!(cigar::BAMCIGAR, mem::MutableMemoryView{UInt8})::BAMCIGAR
     write_offset = 0
     # dummy value for type stability, initial value is not used
-    last_element = CIGARElement(unsafe, UInt32(0x00_00_00_10))
+    last_element = unsafe_cigarelement(UInt32(0x00_00_00_10))
     GC.@preserve mem begin
         for element in cigar
             element.op ∈ (OP_P, OP_H) && continue
@@ -228,11 +227,11 @@ function normalize!(cigar::BAMCIGAR, mem::MutableMemoryView{UInt8})::BAMCIGAR
             ptr = Ptr{UInt32}(pointer(mem) + write_offset)
             unsafe_store!(ptr, u)
             write_offset += 4
-            last_element = CIGARElement(unsafe, u)
+            last_element = unsafe_cigarelement(u)
         end
     end
     mem = @inbounds ImmutableMemoryView(mem)[1:write_offset]
-    return BAMCIGAR(unsafe, mem, cigar.aln_len, cigar.ref_len, cigar.query_len)
+    return unsafe_bamcigar(mem, cigar.aln_len, cigar.ref_len, cigar.query_len)
 end
 
 function normalize(cigar::BAMCIGAR)

--- a/src/bamcigar.jl
+++ b/src/bamcigar.jl
@@ -76,71 +76,10 @@ end
 
 CIGAR(x::BAMCIGAR) = encode_append!(UInt8[], CIGAR, x)
 
-@deprecate CIGAR(x::BAMCIGAR, v::Vector{UInt8}) encode_append!(empty!(v), CIGAR, x)
 
 MemoryViews.MemoryView(x::BAMCIGAR) = x.mem
 
-"""
-    cigar_view!(v::Vector{UInt8}, x::BAMCIGAR)::ImmutableMemoryView{UInt8}
-
-!!! warning
-    This function is DEPRECATED in favor of `encode_append!`
-
-Write the ASCII (i.e. `CIGAR`) representation `x` into `v`,
-emptying `v`'s original content.
-A memory view of `v` is returned:
-
-# Examples
-```jldoctest
-julia> v = [0x01, 0x02, 0x03];
-
-julia> bc = BAMCIGAR(CIGAR("151M3D20M"));
-
-julia> mem_view = cigar_view!(v, bc);
-
-julia> mem_view == v
-true
-
-julia> String(mem_view) == string(CIGAR(bc))
-true
-```
-"""
-function cigar_view! end
-
-@deprecate cigar_view!(v::Vector{UInt8}, x::BAMCIGAR) MemoryView(encode_append!(empty!(v), CIGAR, x))
-
 BAMCIGAR(x::CIGAR) = encode_append!(UInt8[], BAMCIGAR, x)
-
-@deprecate BAMCIGAR(x::CIGAR, v::Vector{UInt8}) encode_append!(empty!(v), BAMCIGAR, x)
-
-"""
-    BAMCIGAR(mem::MutableMemoryView{UInt8}, x::CIGAR)::BAMCIGAR
-
-!!! warning
-    This function is DEPRECATED. Use `encode!(mem, BAMCIGAR, x)`
-
-Construct a `BAMCIGAR` equal to `x`, using the memory `mem`.
-After calling this, `mem` may not be mutated, and is considered
-owned by the resulting `BAMCIGAR`.
-
-Throw a `BoundsError` if `length(mem) < 4 * length(x)`.
-
-# Examples
-```jldoctest
-julia> x = CIGAR("150M3D9S");
-
-julia> mem = MemoryView(zeros(UInt8, 15));
-
-julia> cigar = BAMCIGAR(mem, x)
-BAMCIGAR(CIGAR("150M3D9S"))
-
-julia> parent(MemoryView(cigar)) === parent(mem)
-true
-```
-"""
-BAMCIGAR(::MutableMemoryView{UInt8}, ::CIGAR)
-
-@deprecate BAMCIGAR(mem::MutableMemoryView{UInt8}, x::CIGAR) encode!(mem, BAMCIGAR, x)
 
 function Base.print(io::IO, x::BAMCIGAR)
     v = UInt8[]

--- a/src/bamcigar.jl
+++ b/src/bamcigar.jl
@@ -9,13 +9,12 @@ end
 """
     BAMCIGAR <: AbstractCIGAR
 
-A BAMCIGAR is an alternative representation of a CIGAR,
+A `BAMCIGAR` is an alternative representation of a `CIGAR`,
 stored compactly in 32-bit integers.
-Semantically, a BAMCIGAR behaves much similar to a CIGAR.
+Semantically, a `BAMCIGAR` behaves much similar to a `CIGAR`.
 
-Construct a BAMCIGAR either from a CIGAR, taking an optional `Vector{UInt8}`
-to use as backing storage, or using [`CIGARStrings.try_parse`](@ref),
-or [`BAMCIGAR(::MutableMemoryView{UInt8}, ::CIGAR)`](@ref)
+Construct a `BAMCIGAR` either from a `CIGAR`, or using [`encode!`](@ref)
+or [`encode_append!`](@ref)
 
 # Examples
 ```jldoctest

--- a/src/bamcigar.jl
+++ b/src/bamcigar.jl
@@ -222,7 +222,7 @@ function normalize!(cigar::BAMCIGAR, mem::MutableMemoryView{UInt8})::BAMCIGAR
                 ((len % UInt32) << 4) | reinterpret(UInt8, op)
             else
                 # Append to end
-                @boundscheck checkbounds(mem, write_offset + 4)
+                @boundscheck checkbounds_lightboundserror(mem, write_offset + 4)
                 (getfield(element, :x) & 0xff_ff_ff_f0) | reinterpret(UInt8, op)
             end
             ptr = Ptr{UInt32}(pointer(mem) + write_offset)

--- a/src/bytecigar.jl
+++ b/src/bytecigar.jl
@@ -15,7 +15,7 @@ See also: [`CIGARElement`](@ref)
 CIGAR strings are sequences of `CIGARElement`, from the 5' to the 3' of the
 query (or N- to C-terminal for amino acids).
 CIGAR strings comprise the entire query, i.e. the sum of lengths of elements
-with the `XMI=SH` operations equals the length of the query.
+with the `XMI=S` operations equals the length of the query.
 
 For example, the query `AGCGTAGCACACC` that aligns from query base 5 and ref
 base 1002, like this:
@@ -239,14 +239,12 @@ function normalize!(cigar::CIGAR, mem::MutableMemoryView{UInt8})::CIGAR
     source_mem = MemoryView(cigar)
     while it !== nothing
         (element, new_state) = it
-        if element.op === OP_P
+        if element.op ∈ (OP_P, OP_H)
             state = new_state
             it = iterate(cigar, state)
             continue
         end
-        op = if element.op === OP_H
-            OP_S
-        elseif element.op ∈ (OP_Eq, OP_X)
+        op = if element.op ∈ (OP_Eq, OP_X)
             OP_M
         else
             element.op

--- a/src/bytecigar.jl
+++ b/src/bytecigar.jl
@@ -273,7 +273,7 @@ function normalize!(cigar::CIGAR, mem::MutableMemoryView{UInt8})::CIGAR
             while len > 0
                 n_digits += 1
                 (len, rm) = divrem(len, UInt32(10))
-                @boundscheck checkbounds(mem, write_offset + 1)
+                @boundscheck checkbounds_lightboundserror(mem, write_offset + 1)
                 @inbounds mem[(write_offset += 1)] = rm % UInt8 + 0x30
             end
             # Now, reverse digits in-place
@@ -283,14 +283,14 @@ function normalize!(cigar::CIGAR, mem::MutableMemoryView{UInt8})::CIGAR
                 (mem[a], mem[b]) = (mem[b], mem[a])
             end
             # Now write the operation itself
-            @boundscheck checkbounds(mem, write_offset + 1)
+            @boundscheck checkbounds_lightboundserror(mem, write_offset + 1)
             @inbounds mem[(write_offset += 1)] = op_byte
         else
             previous_element_write_offset = write_offset
             # New operation, so we simply copy the memory of the source to `mem`
             n_bytes = new_state - state
             @boundscheck if length(mem) < write_offset + n_bytes
-                throw(BoundsError(mem, write_offset + n_bytes))
+                throw_lightboundserror(mem, write_offset + n_bytes)
             end
             # Copy over digits
             @inbounds for i in state:(new_state - 2)

--- a/src/bytecigar.jl
+++ b/src/bytecigar.jl
@@ -33,8 +33,7 @@ struct CIGAR <: AbstractCIGAR
     ref_len::UInt32
     query_len::UInt32
 
-    function CIGAR(
-            ::Unsafe,
+    global function unsafe_cigar(
             mem::ImmutableMemoryView{UInt8},
             n_ops::UInt32,
             aln_len::UInt32,
@@ -68,7 +67,7 @@ function Base.iterate(
             b -= UInt8('=') - UInt8('0')
             enc = @inbounds OP_LUT[min(b + 1, 28)]
             op = reinterpret(CIGAROp, enc)
-            return (CIGARElement(unsafe, op, n % UInt32), i + 1)
+            return (unsafe_cigarelement(op, n % UInt32), i + 1)
         end
     end
     return unreachable()
@@ -156,7 +155,7 @@ function try_parse(::Type{CIGAR}, x)::Union{CIGARError, CIGAR}
     if max(aln_len, n_ops, ref_len, query_len) > typemax(UInt32)
         return CIGARError(lastindex(mem), Errors.IntegerOverflow)
     end
-    return CIGAR(unsafe, mem, n_ops % UInt32, aln_len % UInt32, ref_len % UInt32, query_len % UInt32)
+    return unsafe_cigar(mem, n_ops % UInt32, aln_len % UInt32, ref_len % UInt32, query_len % UInt32)
 end
 
 function Base.print(out::IO, cigar::CIGAR)
@@ -202,7 +201,7 @@ false
 ```
 """
 function unsafe_switch_memory(x::CIGAR, mem::ImmutableMemoryView{UInt8})
-    return CIGAR(unsafe, mem, x.n_ops, x.aln_len, x.ref_len, x.query_len)
+    return unsafe_cigar(mem, x.n_ops, x.aln_len, x.ref_len, x.query_len)
 end
 
 function count_matches(x::CIGAR, mismatches::Integer)::Int
@@ -229,7 +228,7 @@ function normalize!(cigar::CIGAR, mem::MutableMemoryView{UInt8})::CIGAR
     state = 1
     it = iterate(cigar, state)
     # dummy value for type stability, initial value is not used
-    last_element = CIGARElement(unsafe, UInt32(0x00_00_00_10))
+    last_element = unsafe_cigarelement(UInt32(0x00_00_00_10))
 
     # When merging elements, we overwrite them. So, to overwrite at the right
     # location, we begin writing at this location. Dummy value to begin with.
@@ -262,7 +261,7 @@ function normalize!(cigar::CIGAR, mem::MutableMemoryView{UInt8})::CIGAR
 
             # Update last element
             u = (len << 4) | reinterpret(UInt8, op)
-            last_element = CIGARElement(unsafe, u)
+            last_element = unsafe_cigarelement(u)
 
             # Write digits, backwards, e.g. write "123" as "321".
             # We write them backwards because that's easiest when using
@@ -303,13 +302,13 @@ function normalize!(cigar::CIGAR, mem::MutableMemoryView{UInt8})::CIGAR
 
             # Update last element
             u = (getfield(element, :x) & 0xff_ff_ff_f0) | reinterpret(UInt8, op)
-            last_element = CIGARElement(unsafe, u)
+            last_element = unsafe_cigarelement(u)
         end
         state = new_state
         it = iterate(cigar, state)
     end
     mem = @inbounds ImmutableMemoryView(mem)[1:write_offset]
-    return CIGAR(unsafe, mem, n_ops % UInt32, cigar.aln_len, cigar.ref_len, cigar.query_len)
+    return unsafe_cigar(mem, n_ops % UInt32, cigar.aln_len, cigar.ref_len, cigar.query_len)
 end
 
 function normalize(cigar::CIGAR)

--- a/src/bytecigar.jl
+++ b/src/bytecigar.jl
@@ -153,7 +153,9 @@ function try_parse(::Type{CIGAR}, x)::Union{CIGARError, CIGAR}
         end
     end
     last_was_num && return CIGARError(lastindex(mem), Errors.Truncated)
-    max(aln_len, n_ops) > typemax(UInt32) && return CIGARError(lastindex(mem), Errors.IntegerOverflow)
+    if max(aln_len, n_ops, ref_len, query_len) > typemax(UInt32)
+        return CIGARError(lastindex(mem), Errors.IntegerOverflow)
+    end
     return CIGAR(unsafe, mem, n_ops % UInt32, aln_len % UInt32, ref_len % UInt32, query_len % UInt32)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using CIGARStrings
 using CIGARStrings: Errors
 using Test
 using MemoryViews
+using LightBoundsErrors: LightBoundsError
 
 # Instantiation and validation
 @testset "Instantiation" begin
@@ -621,7 +622,7 @@ end
             # One byte less is too small
             if needed > 0
                 mem_small = MemoryView(zeros(UInt8, needed - 1))
-                @test_throws BoundsError normalize!(c, mem_small)
+                @test_throws LightBoundsError normalize!(c, mem_small)
             end
         end
     end
@@ -663,7 +664,7 @@ end
             end
         end
 
-        # BoundsError with exactly one byte too little
+        # LightBoundsError with exactly one byte too little
         for s in ["10M5D3I", "150M", "5H9S1D1D1D2I9S6H"]
             c = CIGAR(s)
             bc = BAMCIGAR(c)
@@ -674,7 +675,7 @@ end
                 needed == 0 && continue
                 # One byte too few
                 too_small = MemoryView(zeros(UInt8, needed - 1))
-                @test_throws BoundsError encode!(too_small, T, src)
+                @test_throws LightBoundsError encode!(too_small, T, src)
                 # Exact size works
                 exact = MemoryView(zeros(UInt8, needed))
                 result = encode!(exact, T, src)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -357,14 +357,6 @@ end
         end
     end
 
-    @testset "cigar_view" begin
-        v = UInt8[]
-        c = CIGAR("15M1D19S9H")
-        m = cigar_view!(v, BAMCIGAR(c))
-        @test m isa ImmutableMemoryView{UInt8}
-        @test m == v
-        @test String(m) == string(CIGAR(c))
-    end
 
     @testset "BAMCIGAR actually creates BAMCIGAR" begin
         c = CIGAR("1S5M1D3M2S")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -200,14 +200,14 @@ end
     #       1234    5678 9 012    3
     # R XXXXXXXX----XXXX-X-XXX----XXXX
     # Q HHSS|||......--|.|.-||.....SSS
-    #   1234567890123  4567 8901234567
+    #     12345678901  2345 6789012345
     # A     12345678901234567890123
     s = "2H2S4M4I1X2D1=1I1M1I1D2M4I1X3S"
     for c in [CIGAR(s), BAMCIGAR(CIGAR(s))]
 
         # Getting properties of Translation object
         t = query_to_aln(c, 12)
-        @test t.pos == 8
+        @test t.pos == 12
         @test t.kind == CIGARStrings.pos
 
         t = pos(9)
@@ -226,71 +226,71 @@ end
         @test is_outside(aln_to_query(c, 0))
         @test is_outside(aln_to_ref(c, 0))
         @test is_outside(query_to_aln(c, 1))
-        @test is_outside(query_to_aln(c, 4))
+        @test is_outside(query_to_aln(c, 2))
         @test is_outside(query_to_ref(c, 1))
-        @test is_outside(query_to_ref(c, 4))
+        @test is_outside(query_to_ref(c, 2))
 
         # After alignment
-        @test is_outside(query_to_ref(c, 25))
-        @test is_outside(query_to_aln(c, 25))
+        @test is_outside(query_to_ref(c, 23))
+        @test is_outside(query_to_aln(c, 23))
         @test is_outside(aln_to_query(c, 24))
         @test is_outside(aln_to_ref(c, 24))
         @test is_outside(ref_to_query(c, 14))
         @test is_outside(ref_to_aln(c, 14))
 
         # Within alignment
-        @test query_to_ref(c, 5) == pos(1)
-        @test query_to_aln(c, 5) == pos(1)
-        @test ref_to_query(c, 1) == pos(5)
+        @test query_to_ref(c, 3) == pos(1)
+        @test query_to_aln(c, 3) == pos(1)
+        @test ref_to_query(c, 1) == pos(3)
         @test ref_to_aln(c, 1) == pos(1)
-        @test aln_to_query(c, 1) == pos(5)
+        @test aln_to_query(c, 1) == pos(3)
         @test aln_to_ref(c, 1) == pos(1)
 
         # Various
-        @test query_to_ref(c, 7) == pos(3)
-        @test query_to_ref(c, 8) == pos(4)
+        @test query_to_ref(c, 7) == gap(4)
+        @test query_to_ref(c, 8) == gap(4)
         @test query_to_ref(c, 9) == gap(4)
-        @test query_to_ref(c, 12) == gap(4)
-        @test query_to_ref(c, 13) == pos(5)
-        @test query_to_ref(c, 14) == pos(8)
-        @test query_to_ref(c, 15) == gap(8)
-        @test query_to_ref(c, 16) == pos(9)
-        @test query_to_ref(c, 17) == gap(9)
-        @test query_to_ref(c, 18) == pos(11)
-        @test query_to_ref(c, 19) == pos(12)
+        @test query_to_ref(c, 12) == pos(8)
+        @test query_to_ref(c, 13) == gap(8)
+        @test query_to_ref(c, 14) == pos(9)
+        @test query_to_ref(c, 15) == gap(9)
+        @test query_to_ref(c, 16) == pos(11)
+        @test query_to_ref(c, 17) == pos(12)
+        @test query_to_ref(c, 18) == gap(12)
+        @test query_to_ref(c, 19) == gap(12)
         @test query_to_ref(c, 20) == gap(12)
-        @test query_to_ref(c, 23) == gap(12)
-        @test query_to_ref(c, 24) == pos(13)
+        @test query_to_ref(c, 22) == pos(13)
+        @test is_outside(query_to_ref(c, 23))
 
-        @test query_to_aln(c, 9) == pos(5)
-        @test query_to_aln(c, 13) == pos(9)
-        @test query_to_aln(c, 14) == pos(12)
-        @test query_to_aln(c, 17) == pos(15)
-        @test query_to_aln(c, 18) == pos(17)
-        @test query_to_aln(c, 19) == pos(18)
-        @test query_to_aln(c, 24) == pos(23)
+        @test query_to_aln(c, 9) == pos(7)
+        @test query_to_aln(c, 13) == pos(13)
+        @test query_to_aln(c, 14) == pos(14)
+        @test query_to_aln(c, 17) == pos(18)
+        @test query_to_aln(c, 18) == pos(19)
+        @test query_to_aln(c, 19) == pos(20)
+        @test query_to_aln(c, 22) == pos(23)
 
-        @test aln_to_query(c, 9) == pos(13)
-        @test aln_to_query(c, 10) == gap(13)
-        @test aln_to_query(c, 11) == gap(13)
-        @test aln_to_query(c, 12) == pos(14)
-        @test aln_to_query(c, 13) == pos(15)
-        @test aln_to_query(c, 14) == pos(16)
-        @test aln_to_query(c, 15) == pos(17)
-        @test aln_to_query(c, 16) == gap(17)
-        @test aln_to_query(c, 17) == pos(18)
-        @test aln_to_query(c, 18) == pos(19)
-        @test aln_to_query(c, 19) == pos(20)
-        @test aln_to_query(c, 23) == pos(24)
+        @test aln_to_query(c, 9) == pos(11)
+        @test aln_to_query(c, 10) == gap(11)
+        @test aln_to_query(c, 11) == gap(11)
+        @test aln_to_query(c, 12) == pos(12)
+        @test aln_to_query(c, 13) == pos(13)
+        @test aln_to_query(c, 14) == pos(14)
+        @test aln_to_query(c, 15) == pos(15)
+        @test aln_to_query(c, 16) == gap(15)
+        @test aln_to_query(c, 17) == pos(16)
+        @test aln_to_query(c, 18) == pos(17)
+        @test aln_to_query(c, 19) == pos(18)
+        @test aln_to_query(c, 23) == pos(22)
 
-        @test ref_to_query(c, 5) == pos(13)
-        @test ref_to_query(c, 6) == gap(13)
-        @test ref_to_query(c, 7) == gap(13)
-        @test ref_to_query(c, 8) == pos(14)
-        @test ref_to_query(c, 9) == pos(16)
-        @test ref_to_query(c, 10) == gap(17)
-        @test ref_to_query(c, 11) == pos(18)
-        @test ref_to_query(c, 13) == pos(24)
+        @test ref_to_query(c, 5) == pos(11)
+        @test ref_to_query(c, 6) == gap(11)
+        @test ref_to_query(c, 7) == gap(11)
+        @test ref_to_query(c, 8) == pos(12)
+        @test ref_to_query(c, 9) == pos(14)
+        @test ref_to_query(c, 10) == gap(15)
+        @test ref_to_query(c, 11) == pos(16)
+        @test ref_to_query(c, 13) == pos(22)
 
         @test ref_to_aln(c, 1) == pos(1)
         @test ref_to_aln(c, 4) == pos(4)
@@ -441,21 +441,18 @@ end
         @test is_compatible(CIGAR("5M"), CIGAR("5X"))
         @test is_compatible(CIGAR("10M"), CIGAR("3=4X3="))
 
-        # OP_S and OP_H are semantically identical
-        @test is_compatible(CIGAR("2S"), CIGAR("2H"))
-        @test is_compatible(CIGAR("3H5M2S"), CIGAR("3S5M2H"))
-        @test is_compatible(CIGAR("1H1S"), CIGAR("2H"))
-        @test is_compatible(CIGAR("1S1H"), CIGAR("2S"))
-
-        # OP_P has no semantic meaning and is skipped
+        # OP_P and OP_H has no semantic meaning and is skipped
         @test is_compatible(CIGAR("1D1P2D1M3P"), CIGAR("3D1M"))
         @test is_compatible(CIGAR("5P"), CIGAR(""))
         @test is_compatible(CIGAR("1P1P1P"), CIGAR(""))
         @test is_compatible(CIGAR("2M1P3M"), CIGAR("2M3M"))
         @test is_compatible(CIGAR("1P2M1P3I1P"), CIGAR("2M3I"))
+        @test is_compatible(CIGAR("3H5M"), CIGAR("3=2X"))
+        @test is_compatible(CIGAR("3H5M2H"), CIGAR("3=2X"))
+        @test is_compatible(CIGAR("5M2H"), CIGAR("2=3X"))
 
         # Complex combinations
-        @test is_compatible(CIGAR("1H1S3M1P2I"), CIGAR("2S1=2M2I"))
+        @test is_compatible(CIGAR("1H1S3M1P2I"), CIGAR("1S1=2M2I"))
 
         # Incompatible CIGARs
         @test !is_compatible(CIGAR("1="), CIGAR("1X"))
@@ -466,7 +463,7 @@ end
         @test !is_compatible(CIGAR("5="), CIGAR("4=1X"))
         @test !is_compatible(CIGAR("10M"), CIGAR(""))
         @test !is_compatible(CIGAR(""), CIGAR("10M"))
-        @test !is_compatible(CIGAR("1S2M3I2H"), CIGAR("1S2M3I"))
+        @test !is_compatible(CIGAR("1S2M3I"), CIGAR("1S2M2I"))
     end
 
     @testset "BAMCIGAR with BAMCIGAR" begin
@@ -484,13 +481,11 @@ end
         @test is_compatible(BAMCIGAR(CIGAR("3M")), BAMCIGAR(CIGAR("1X1M1=")))
         @test is_compatible(BAMCIGAR(CIGAR("1D2M3I")), BAMCIGAR(CIGAR("1D1X1M3I")))
 
-        # OP_S and OP_H are semantically identical
-        @test is_compatible(BAMCIGAR(CIGAR("2S")), BAMCIGAR(CIGAR("2H")))
-        @test is_compatible(BAMCIGAR(CIGAR("3H5M2S")), BAMCIGAR(CIGAR("3S5M2H")))
-
-        # OP_P has no semantic meaning
+        # OP_P and OP_H have no semantic meaning
         @test is_compatible(BAMCIGAR(CIGAR("1D1P2D1M3P")), BAMCIGAR(CIGAR("3D1M")))
         @test is_compatible(BAMCIGAR(CIGAR("5P")), BAMCIGAR(CIGAR("")))
+        @test is_compatible(BAMCIGAR(CIGAR("3H5M")), BAMCIGAR(CIGAR("3=2X")))
+        @test is_compatible(BAMCIGAR(CIGAR("3H5M2H")), BAMCIGAR(CIGAR("3=2X")))
 
         # Incompatible CIGARs
         @test !is_compatible(BAMCIGAR(CIGAR("1=")), BAMCIGAR(CIGAR("1X")))
@@ -509,8 +504,8 @@ end
         @test is_compatible(CIGAR("3M"), BAMCIGAR(CIGAR("1X1=1M")))
         @test is_compatible(BAMCIGAR(CIGAR("5M")), CIGAR("2=3X"))
 
-        @test is_compatible(CIGAR("2S"), BAMCIGAR(CIGAR("2H")))
-        @test is_compatible(BAMCIGAR(CIGAR("3H5M")), CIGAR("3S5M"))
+        @test is_compatible(CIGAR("3H5M"), BAMCIGAR(CIGAR("3=2X")))
+        @test is_compatible(BAMCIGAR(CIGAR("3H5M2H")), CIGAR("3=2X"))
 
         @test is_compatible(CIGAR("2M1P3M"), BAMCIGAR(CIGAR("5M")))
         @test is_compatible(BAMCIGAR(CIGAR("1P2D1P")), CIGAR("2D"))
@@ -533,8 +528,8 @@ end
         # Eq and X converted to M, merged with existing M
         @test normalize(make(T, "1=1X1M")) == make(T, "3M")
 
-        # H at ends becomes S
-        @test normalize(make(T, "3H10M2H")) == make(T, "3S10M2S")
+        # H is deleted
+        @test normalize(make(T, "3H10M2H")) == make(T, "10M")
 
         # Already normalized: unchanged
         @test normalize(make(T, "5M1D8M1I7M")) == make(T, "5M1D8M1I7M")
@@ -554,7 +549,7 @@ end
         @test normalize(make(T, "5M3N10M")) == make(T, "5M3N10M")
 
         # Single element conversions
-        @test normalize(make(T, "5H")) == make(T, "5S")
+        @test normalize(make(T, "5H")) == make(T, "")
         @test normalize(make(T, "5=")) == make(T, "5M")
         @test normalize(make(T, "5X")) == make(T, "5M")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,22 @@ using MemoryViews
         @test CIGARStrings.try_parse(CIGAR, bad).kind == err
     end
 
+    @testset "try_parse catches total length overflow" begin
+        maxop = "268435455"
+
+        # Ref length overflows UInt32 while aln length stays tiny.
+        ref_overflow = repeat(maxop * "N", 17) * "1M"
+        err = CIGARStrings.try_parse(CIGAR, ref_overflow)
+        @test err isa CIGARStrings.CIGARError
+        @test err.kind == Errors.IntegerOverflow
+
+        # Query length overflows UInt32 while aln length is still <= UInt32 max.
+        query_overflow = maxop * "S" * repeat(maxop * "I", 14) * "16I" * maxop * "S"
+        err = CIGARStrings.try_parse(CIGAR, query_overflow)
+        @test err isa CIGARStrings.CIGARError
+        @test err.kind == Errors.IntegerOverflow
+    end
+
     @testset "unsafe_switch_memory" begin
         for str in [
                 "",
@@ -333,6 +349,38 @@ end
                 ("\x10\0\0\0\x14\0\0\0\x10\0\0\0", Errors.InvalidSoftClip),
             ]
             @test CIGARStrings.try_parse(BAMCIGAR, bad).kind == err
+        end
+
+        @testset "try_parse catches total length overflow" begin
+            n = UInt32(268435455)
+            push_u32le!(v::Vector{UInt8}, x::UInt32) = append!(v, reinterpret(UInt8, [htol(x)]))
+
+            # Ref length overflows UInt32 while aln length stays tiny.
+            ref_bytes = UInt8[]
+            op_n = (n << 4) | UInt32(0x03)
+            op_m = (UInt32(1) << 4) | UInt32(0x00)
+            for _ in 1:17
+                push_u32le!(ref_bytes, op_n)
+            end
+            push_u32le!(ref_bytes, op_m)
+            err = CIGARStrings.try_parse(BAMCIGAR, ref_bytes)
+            @test err isa CIGARStrings.CIGARError
+            @test err.kind == Errors.IntegerOverflow
+
+            # Query length overflows UInt32 while aln length is still <= UInt32 max.
+            query_bytes = UInt8[]
+            op_s = (n << 4) | UInt32(0x04)
+            op_i = (n << 4) | UInt32(0x01)
+            op_i16 = (UInt32(16) << 4) | UInt32(0x01)
+            push_u32le!(query_bytes, op_s)
+            for _ in 1:14
+                push_u32le!(query_bytes, op_i)
+            end
+            push_u32le!(query_bytes, op_i16)
+            push_u32le!(query_bytes, op_s)
+            err = CIGARStrings.try_parse(BAMCIGAR, query_bytes)
+            @test err isa CIGARStrings.CIGARError
+            @test err.kind == Errors.IntegerOverflow
         end
     end
 


### PR DESCRIPTION
## Breaking:
- Remove CIGAR(::BAMCIGAR, ::Vector{UInt8}), cigar_view!, BAMCIGAR(::CIGAR, ::Vector{UInt8}), and
BAMCIGAR(::MutableMemoryView{UInt8}, ::CIGAR), which were deprecated in favor of encode!/encode_append!.
* Code now throws LightBoundsErrors instead of BoundsErrors
* `OP_H` no longer consumes the query.

## Other
Various bugfixes